### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', 2.7, 2.6, 2.5]
+        ruby-version: [3.1, '3.0', 2.7, 2.6, 2.5]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.